### PR TITLE
fix: resolve info icon positioning bug in SummaryPanel (issue #3)

### DIFF
--- a/thoughts/shared/plans/2025-11-25-issue-3-info-icon-positioning.md
+++ b/thoughts/shared/plans/2025-11-25-issue-3-info-icon-positioning.md
@@ -1,0 +1,187 @@
+# Info Icon Positioning Bug Fix (Issue #3) Implementation Plan
+
+## Overview
+
+Fix the info icon positioning bug in SummaryPanel where the icon appears near the title instead of next to the λ value. The root cause is an unscoped `.info-icon` CSS selector in LambdaSlider.css that leaks `position: absolute` to all elements with that class.
+
+## Current State Analysis
+
+### The Bug
+- SummaryPanel's info icon visually appears near the "Half of America" title
+- DOM inspection confirms the icon IS correctly placed inside `.technical-stats`
+- `getComputedStyle()` shows `position: absolute` even though SummaryPanel.css doesn't define it
+
+### Root Cause
+`LambdaSlider.css:32-49` defines an unscoped `.info-icon` selector:
+```css
+.info-icon {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  /* ... */
+}
+```
+
+This acts as a global style affecting ALL `.info-icon` elements. SummaryPanel.css defines `.summary-panel .info-icon` with higher specificity but doesn't override `position`, so the absolute positioning leaks through.
+
+### Key Discoveries
+- `web/src/components/LambdaSlider.css:32-49` - Unscoped `.info-icon` with `position: absolute`
+- `web/src/components/LambdaSlider.css:51-57` - Unscoped `.info-icon:hover, .info-icon:focus`
+- `web/src/components/LambdaSlider.css:59-62` - Unscoped `.info-icon:focus-visible`
+- `web/src/components/SummaryPanel.css:33-48` - Scoped `.summary-panel .info-icon` (missing position override)
+
+## Desired End State
+
+- SummaryPanel info icon appears in the bottom-right corner next to "λ = 0.50"
+- SummaryPanel tooltip appears above the technical-stats section (near bottom of panel)
+- LambdaSlider info icon continues to appear in top-right corner of its panel
+- LambdaSlider tooltip continues to work correctly
+- No global CSS selectors for `.info-icon`
+
+## What We're NOT Doing
+
+- Adding defensive `position: static` to SummaryPanel.css (masks root cause)
+- Renaming CSS classes (unnecessary churn)
+- Refactoring to CSS modules or scoped styles (over-engineering)
+
+## Implementation Approach
+
+Scope all `.info-icon` selectors in LambdaSlider.css to `.lambda-slider .info-icon` to prevent style leakage to other components.
+
+## Phase 1: Scope LambdaSlider CSS Selectors
+
+### Overview
+Change all unscoped `.info-icon` selectors in LambdaSlider.css to be scoped under `.lambda-slider`.
+
+### Changes Required
+
+#### 1. LambdaSlider.css
+**File**: `web/src/components/LambdaSlider.css`
+
+**Change 1**: Scope the main `.info-icon` selector (lines 32-49)
+
+```css
+/* Before */
+.info-icon {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+/* After */
+.lambda-slider .info-icon {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+```
+
+**Change 2**: Scope the hover/focus selectors (lines 51-57)
+
+```css
+/* Before */
+.info-icon:hover,
+.info-icon:focus {
+  background: rgba(0, 114, 178, 0.2);
+  border-color: rgba(0, 114, 178, 0.6);
+  color: #0072B2;
+  outline: none;
+}
+
+/* After */
+.lambda-slider .info-icon:hover,
+.lambda-slider .info-icon:focus {
+  background: rgba(0, 114, 178, 0.2);
+  border-color: rgba(0, 114, 178, 0.6);
+  color: #0072B2;
+  outline: none;
+}
+```
+
+**Change 3**: Scope the focus-visible selector (lines 59-62)
+
+```css
+/* Before */
+.info-icon:focus-visible {
+  outline: 2px solid #0072B2;
+  outline-offset: 2px;
+}
+
+/* After */
+.lambda-slider .info-icon:focus-visible {
+  outline: 2px solid #0072B2;
+  outline-offset: 2px;
+}
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Build succeeds: `cd web && npm run build`
+- [ ] Lint passes: `cd web && npm run lint`
+- [ ] No TypeScript errors (CSS changes only, but verify build)
+
+#### Manual Verification:
+- [ ] SummaryPanel info icon appears next to λ value (bottom-right of panel)
+- [ ] SummaryPanel tooltip appears above the panel content (near bottom of screen)
+- [ ] LambdaSlider info icon still appears in top-right corner of slider panel
+- [ ] LambdaSlider tooltip still appears below the slider panel (desktop) / above (mobile)
+- [ ] Hover/focus states work correctly on both info icons
+- [ ] Test on mobile viewport (≤767px)
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause for manual confirmation that the visual positioning is correct before closing the issue.
+
+---
+
+## Testing Strategy
+
+### Visual Testing Steps
+1. Run dev server: `cd web && npm run dev`
+2. Open browser to `http://localhost:5173`
+3. **Desktop (≥768px)**:
+   - Verify LambdaSlider panel in top-left with info icon in its top-right corner
+   - Verify SummaryPanel in top-right with info icon next to "λ = X.XX" at bottom
+   - Click each info icon and verify tooltip positioning
+4. **Mobile (≤767px)**:
+   - Resize browser or use DevTools device mode
+   - Verify LambdaSlider at bottom with info icon in top-right of that panel
+   - Verify SummaryPanel info icon visible and correctly positioned
+   - Test tooltip positioning on mobile
+
+### Edge Cases
+- Rapid toggling of tooltips
+- Keyboard navigation (Tab to info icon, Enter to activate)
+- Focus states visible with keyboard navigation
+
+## References
+
+- GitHub Issue: https://github.com/stevenfazzio/half-america/issues/3
+- Research document: `thoughts/shared/research/2025-11-25-issue-3-info-icon-positioning.md`
+- LambdaSlider CSS: `web/src/components/LambdaSlider.css:32-62`
+- SummaryPanel CSS: `web/src/components/SummaryPanel.css:33-61`

--- a/thoughts/shared/plans/2025-11-25-issue-3-info-icon-positioning.md
+++ b/thoughts/shared/plans/2025-11-25-issue-3-info-icon-positioning.md
@@ -143,17 +143,17 @@ Change all unscoped `.info-icon` selectors in LambdaSlider.css to be scoped unde
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Build succeeds: `cd web && npm run build`
-- [ ] Lint passes: `cd web && npm run lint`
-- [ ] No TypeScript errors (CSS changes only, but verify build)
+- [x] Build succeeds: `cd web && npm run build`
+- [x] Lint passes: `cd web && npm run lint`
+- [x] No TypeScript errors (CSS changes only, but verify build)
 
 #### Manual Verification:
-- [ ] SummaryPanel info icon appears next to λ value (bottom-right of panel)
-- [ ] SummaryPanel tooltip appears above the panel content (near bottom of screen)
-- [ ] LambdaSlider info icon still appears in top-right corner of slider panel
-- [ ] LambdaSlider tooltip still appears below the slider panel (desktop) / above (mobile)
-- [ ] Hover/focus states work correctly on both info icons
-- [ ] Test on mobile viewport (≤767px)
+- [x] SummaryPanel info icon appears next to λ value (bottom-right of panel)
+- [x] SummaryPanel tooltip appears below the panel
+- [x] LambdaSlider info icon still appears in top-right corner of slider panel
+- [x] LambdaSlider tooltip still appears below the slider panel (desktop) / above (mobile)
+- [x] Hover/focus states work correctly on both info icons
+- [x] Test on mobile viewport (≤767px)
 
 **Implementation Note**: After completing this phase and all automated verification passes, pause for manual confirmation that the visual positioning is correct before closing the issue.
 

--- a/thoughts/shared/research/2025-11-25-issue-3-info-icon-positioning.md
+++ b/thoughts/shared/research/2025-11-25-issue-3-info-icon-positioning.md
@@ -1,0 +1,165 @@
+---
+date: 2025-11-25T17:30:00-08:00
+researcher: Claude
+git_commit: 0debb03685b8964c81fd333cb1b5c2afa1b7ed10
+branch: fix/3-info-icon-positioning
+repository: half-america
+topic: "Info icon in SummaryPanel has phantom absolute positioning"
+tags: [research, codebase, css, bug, positioning, issue-3]
+status: complete
+last_updated: 2025-11-25
+last_updated_by: Claude
+---
+
+# Research: Info Icon Positioning Bug (Issue #3)
+
+**Date**: 2025-11-25T17:30:00-08:00
+**Researcher**: Claude
+**Git Commit**: 0debb03685b8964c81fd333cb1b5c2afa1b7ed10
+**Branch**: fix/3-info-icon-positioning
+**Repository**: half-america
+
+## Research Question
+
+Why does the info icon in SummaryPanel appear in the wrong position (near the title) when the DOM shows it's correctly placed inside `.technical-stats`, and why does `getComputedStyle()` show `position: absolute` when SummaryPanel.css doesn't define it?
+
+## Summary
+
+**Root Cause Found**: The bug is caused by a CSS specificity/cascade issue.
+
+`LambdaSlider.css` defines an **unscoped** `.info-icon` selector with `position: absolute`, which acts as a global style affecting ALL elements with that class, including the info icon in SummaryPanel.
+
+`SummaryPanel.css` defines `.summary-panel .info-icon` with higher specificity, but it does NOT override the `position` property, allowing the absolute positioning from LambdaSlider.css to leak through.
+
+## Detailed Findings
+
+### The Conflicting CSS Rules
+
+**LambdaSlider.css:32-49** (unscoped selector - affects ALL `.info-icon` elements):
+```css
+.info-icon {
+  position: absolute;    /* <-- THIS IS THE PROBLEM */
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  /* ... other properties ... */
+}
+```
+
+**SummaryPanel.css:33-48** (scoped selector - but missing position override):
+```css
+.summary-panel .info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  /* ... other properties ... */
+  /* NOTE: No `position` property defined! */
+}
+```
+
+### CSS Cascade Behavior
+
+1. `.info-icon` (specificity: 0,0,1,0) sets `position: absolute`
+2. `.summary-panel .info-icon` (specificity: 0,0,2,0) overrides properties it defines
+3. Since `.summary-panel .info-icon` doesn't define `position`, the value from `.info-icon` wins by default
+4. Result: The SummaryPanel info icon gets `position: absolute; top: 16px; right: 16px;` from LambdaSlider.css
+
+### Why the Icon Appears Near the Title
+
+With `position: absolute; top: 16px; right: 16px;`:
+- The icon is removed from normal document flow
+- It positions relative to the nearest positioned ancestor (`.summary-panel` with `position: fixed`)
+- It appears at top-right of the panel (16px from top, 16px from right)
+- This visually places it near the "Half of America" title instead of next to the lambda value
+
+### Related Tooltip Issue
+
+The tooltip positioning problem mentioned in the issue is also explained:
+- `.scope-tooltip` uses `position: absolute; bottom: 100%` to position above its parent
+- But since the info icon is absolutely positioned at the top of `.summary-panel`, the tooltip appears above the panel (near where the icon actually renders)
+- Expected: tooltip should appear above the `technical-stats` section at the bottom
+
+## Code References
+
+- `web/src/components/LambdaSlider.css:32-49` - Unscoped `.info-icon` with `position: absolute`
+- `web/src/components/SummaryPanel.css:33-48` - Scoped `.summary-panel .info-icon` missing position override
+- `web/src/components/SummaryPanel.css:64-78` - `.scope-tooltip` positioning
+- `web/src/components/SummaryPanel.tsx:67-78` - Info icon JSX placement in DOM
+- `web/src/components/SummaryPanel.tsx:81-98` - Tooltip JSX (sibling of `.technical-stats`)
+
+## Architecture Insights
+
+The codebase has two info icon implementations:
+1. **LambdaSlider**: Icon intentionally positioned absolutely in top-right corner
+2. **SummaryPanel**: Icon should flow inline with the lambda value
+
+Both share the `.info-icon` class name but need different positioning strategies. The current implementation accidentally creates a global style from what should be a component-scoped style.
+
+## Recommended Fixes
+
+### Option A: Scope the LambdaSlider selector (Preferred)
+
+Change `LambdaSlider.css` to use a scoped selector:
+
+```css
+/* Before */
+.info-icon {
+  position: absolute;
+  ...
+}
+
+/* After */
+.lambda-slider .info-icon {
+  position: absolute;
+  ...
+}
+```
+
+**Pros**: Fixes the root cause, prevents future leakage
+**Cons**: Need to update hover/focus selectors too
+
+### Option B: Add explicit position to SummaryPanel
+
+Add `position: static` to `SummaryPanel.css`:
+
+```css
+.summary-panel .info-icon {
+  position: static;  /* Override the leaked absolute positioning */
+  ...
+}
+```
+
+**Pros**: Quick fix, minimal changes
+**Cons**: Doesn't fix the root cause (global selector remains)
+
+### Option C: Both (Most Thorough)
+
+Apply both fixes:
+1. Scope the LambdaSlider selectors
+2. Add explicit position to SummaryPanel for defensive CSS
+
+## Files Requiring Changes
+
+| File | Change Required |
+|------|-----------------|
+| `web/src/components/LambdaSlider.css` | Scope `.info-icon` to `.lambda-slider .info-icon` |
+| `web/src/components/SummaryPanel.css` | (Optional) Add `position: static` defensively |
+
+## Testing Plan
+
+1. Run dev server: `cd web && npm run dev`
+2. Verify SummaryPanel info icon appears next to lambda value (bottom-right of panel)
+3. Verify SummaryPanel tooltip appears above the panel (near bottom of panel)
+4. Verify LambdaSlider info icon still appears in top-right corner
+5. Verify LambdaSlider tooltip still appears below the slider panel
+6. Test on mobile viewport (icon visibility, tooltip positioning)
+
+## Open Questions
+
+None - root cause identified and fix is straightforward.

--- a/web/src/components/LambdaSlider.css
+++ b/web/src/components/LambdaSlider.css
@@ -7,8 +7,13 @@
   background: rgba(30, 30, 30, 0.95);
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  z-index: 10;
+  z-index: 100;
   color: #fff;
+}
+
+/* Raise panel above other UI when tooltip is visible */
+.lambda-slider:has(.lambda-tooltip) {
+  z-index: 10000;
 }
 
 @media (min-width: 768px) {
@@ -29,7 +34,7 @@
 }
 
 /* Info icon button */
-.info-icon {
+.lambda-slider .info-icon {
   position: absolute;
   top: 16px;
   right: 16px;
@@ -48,15 +53,15 @@
   transition: all 0.2s ease;
 }
 
-.info-icon:hover,
-.info-icon:focus {
+.lambda-slider .info-icon:hover,
+.lambda-slider .info-icon:focus {
   background: rgba(0, 114, 178, 0.2);
   border-color: rgba(0, 114, 178, 0.6);
   color: #0072B2;
   outline: none;
 }
 
-.info-icon:focus-visible {
+.lambda-slider .info-icon:focus-visible {
   outline: 2px solid #0072B2;
   outline-offset: 2px;
 }

--- a/web/src/components/SummaryPanel.css
+++ b/web/src/components/SummaryPanel.css
@@ -11,6 +11,11 @@
   min-width: 160px;
 }
 
+/* Raise panel above other UI when tooltip is visible */
+.summary-panel:has(.scope-tooltip) {
+  z-index: 10000;
+}
+
 @media (max-width: 767px) {
   .summary-panel {
     top: 16px;
@@ -63,10 +68,10 @@
 /* Scope tooltip */
 .scope-tooltip {
   position: absolute;
-  bottom: 100%;
+  top: 100%;
   left: 0;
   right: 0;
-  margin-bottom: 8px;
+  margin-top: 8px;
   padding: 14px;
   background: rgba(0, 0, 0, 0.98);
   border: 1px solid rgba(0, 114, 178, 0.4);


### PR DESCRIPTION
## Summary

- Scoped `.info-icon` CSS selectors in LambdaSlider.css to prevent style leakage to other components
- Fixed SummaryPanel tooltip to appear below the panel instead of above
- Added `:has()` selectors to dynamically elevate z-index when tooltips are active, ensuring they always render above other UI elements

## Root Cause

Unscoped `.info-icon` selector in LambdaSlider.css was applying `position: absolute` globally, affecting SummaryPanel's info icon positioning.

## Test Plan

- [x] Build succeeds
- [x] Lint passes
- [x] Python tests pass
- [x] Manual verification on desktop and mobile viewports
- [x] Both tooltips appear above all other UI elements
- [x] Hover/focus states work correctly

Closes #3